### PR TITLE
fix /tmp paths and rm flags

### DIFF
--- a/docs/v0.21/testing-0.21rc2.md
+++ b/docs/v0.21/testing-0.21rc2.md
@@ -382,7 +382,7 @@ You've reached the end of the regularly scheduled programming. Take a little tim
 Use this command to remove all the data you played around with:
 
 ```bash
-rm /tmp/21-rc-test/
+rm -rf /tmp/21-rc-test/
 ```
 
 ## The Most Important Step

--- a/docs/v0.21/testing-0.21rc2.md
+++ b/docs/v0.21/testing-0.21rc2.md
@@ -68,13 +68,13 @@ We will now run `bitcoin-qt` and provide a data directory:
 ###### Source code
 
 ``` bash
-./src/qt/bitcoin-qt --datadir=./tmp/21-rc-test
+./src/qt/bitcoin-qt --datadir=/tmp/21-rc-test
 ```
 
 ###### Binary Build
 
 ``` bash
-./bin/bitcoin-qt --datadir=./tmp/21-rc-test
+./bin/bitcoin-qt --datadir=/tmp/21-rc-test
 ```
 
 ##### Create new Descriptor Wallet
@@ -130,13 +130,13 @@ OK. You'll need two terminal windows.
 
 In the first, you'll need to start your node:
 ```
-./src/bitcoind --datadir=./tmp/21-rc-test
+./src/bitcoind --datadir=/tmp/21-rc-test
 ```
 
 And in the other, you can create your wallet:
 
 ```
-./src/bitcoin-cli --datadir=./tmp/21-rc-test -named createwallet wallet_name="my-descriptor-wallet" descriptors=true
+./src/bitcoin-cli --datadir=/tmp/21-rc-test -named createwallet wallet_name="my-descriptor-wallet" descriptors=true
 ```
 
 While the logs fly by in that `bitcoind` window, once you've created a wallet you should see something like:
@@ -151,7 +151,7 @@ While the logs fly by in that `bitcoind` window, once you've created a wallet yo
 Now let's check it's what we want. In that wallet window add:
 
 ```
-./src/bitcoin-cli --datadir=./tmp/21-rc-test getwalletinfo
+./src/bitcoin-cli --datadir=/tmp/21-rc-test getwalletinfo
 ```
 
 Which should result in something like:
@@ -231,7 +231,7 @@ We are going to setup our node to [listen on Tor automatically](https://github.c
 The `bitcoin.conf` file is used to [configure](https://en.bitcoin.it/wiki/Running_Bitcoin#Bitcoin.conf_Configuration_File) how your node will run. This file is not automatically created and must be created manually. This file will be created in the data directory that we previously created while testing the wallet. From your data directory, run:
 
 ``` bash
-touch ./tmp/21-rc-test/bitcoin.conf
+touch /tmp/21-rc-test/bitcoin.conf
 ```
 
 We will be adding settings to the bitcoin.conf that will allow us to connect and find peers through the Tor network. Since the Bitcoin Core 0.21 release has not actually been released yet, `Torv3` nodes are rare to come across. Because of this, we are going to manually add a `Torv3` node that has been tracked down. Using your favorite text editor, add the following to the newly created `bitcoin.conf` file:
@@ -256,13 +256,13 @@ Ready to test? There are two ways to try this.
 ##### 3a. Start bitcoind
 
 ```bash
-./src/bitcoind --datadir=./tmp/21-rc-test
+./src/bitcoind --datadir=/tmp/21-rc-test
 ```
 
 You will see a flurry of messages as the logs pass by. Open a new terminal window and let's query our running node to see who we've connected to:
 
 ```bash
-./src/bitcoin-cli --datadir=./tmp/21-rc-test getpeerinfo
+./src/bitcoin-cli --datadir=/tmp/21-rc-test getpeerinfo
 ```
 
 This should show you a list of peers. This is what a first one might look like:
@@ -288,13 +288,13 @@ Launch `bitcoin-qt` and provide the data directory we have been using:
 ###### Source code
 
 ``` bash
-./src/qt/bitcoin-qt --datadir=./tmp/21-rc-test
+./src/qt/bitcoin-qt --datadir=/tmp/21-rc-test
 ```
 
 ###### Binary Build
 
 ``` bash
-./bin/bitcoin-qt --datadir=./tmp/21-rc-test
+./bin/bitcoin-qt --datadir=/tmp/21-rc-test
 ```
 
 ###### Check for Tor peers
@@ -313,7 +313,7 @@ You can differentiate a Torv3 node from a Torv2 node by looking at how long it i
 We want to delete the `bitcoin.conf` in our data directory as we no longer need these configurations.
 
 ``` bash
-rm ./tmp/21-rc-test/bitcoin.conf
+rm /tmp/21-rc-test/bitcoin.conf
 ```
 
 ---
@@ -382,7 +382,7 @@ You've reached the end of the regularly scheduled programming. Take a little tim
 Use this command to remove all the data you played around with:
 
 ```bash
-rm ./tmp/21-rc-test/
+rm /tmp/21-rc-test/
 ```
 
 ## The Most Important Step


### PR DESCRIPTION
- `./tmp` is a directory relative to the current working directory (indicated by the dot at the beginning). We want to use the absolute path to `/tmp`.
- rm alone can't remove directorys. Both -r (recursive) and -f (force, i.e. don't ask for each file) is needed to remove directory.